### PR TITLE
Templates support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Simpliest playbook can be following:
       app_docker_tag: 'latest'
       app_ports_mapping: ['3000:3000']
 ```
-This playbook will pull image maticinsurace/rails-app:latest, 
+This playbook will pull image maticinsurace/rails-app:latest,
 run migrations `bundle exec rake db:migrate` and start rails app `bundle exec rails s`
 
 If you want to specify additional environment variables:
@@ -82,7 +82,7 @@ If you want to specify additional environment variables:
   roles:
     - role: rails-container-app
       app_command: 'bundle exec sidekiq'
-      app_environment_vars: 
+      app_environment_vars:
         REDIS_URL: redis://redis.host:6379
         DATABASE_URL: postgress://db.host:5432
 ```
@@ -94,13 +94,24 @@ If you want custom files to be deployed to the app:
   roles:
     - role: rails-container-app
       app_files_local_folder: './files/webserver'
-      app_configuration_files: 
+      app_configuration_files:
         settings.yaml: /app/config/settings.local.yaml
         apns_cert.pem: certs/apns.pem
 ```
 This will read file from local machine using key as path after `app_files_local_folder`
-and mount them to docker image using value as path. E.g `./files/webserver/settings.yaml` 
+and mount them to docker image using value as path. E.g `./files/webserver/settings.yaml`
 will be mounted as `/app/config/settings.local.yam:ro`
+
+The same way you can render Jinja2 templates via `app_configuration_templates`:
+
+```yaml
+- hosts: webservers
+  roles:
+    - role: rails-container-app
+      app_templates_local_folder: './templates/webserver'
+      app_configuration_templates:
+        settings.local.yml.j2: /app/config/settings.local.yml
+```
 
 License
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,6 +35,8 @@ app_configuration_templates: {}
 app_environment: production
 # Folder with all config files on local machine
 app_files_local_folder: './files'
+# Folder with all config templates on local machine
+app_templates_local_folder: './templates'
 #Force image pull
 app_force_image_pull: true
 #Docker container restart policy

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,8 @@ app_command: 'bundle exec rails s'
 app_environment_vars: {}
 # Configuration files to deploy on server and mount to image
 app_configuration_files: {}
+# Configuration jinja2 templates to deploy on server and mount to image
+app_configuration_templates: {}
 
 ###########################################################################
 # Optional settings

--- a/tasks/_1_pull_image.yml
+++ b/tasks/_1_pull_image.yml
@@ -8,7 +8,8 @@
 
 - name: 'Image: pull'
   docker_image:
-    force: '{{ app_force_image_pull }}'
+    force_source: '{{ app_force_image_pull }}'
     name: '{{ app_docker_image }}'
     tag: '{{ app_docker_image_tag }}'
+    source: pull
   register: app_docker_image_status

--- a/tasks/_2_prepare_configs.yml
+++ b/tasks/_2_prepare_configs.yml
@@ -9,14 +9,21 @@
     path: "{{ app_settings_path + '/' + item.value | dirname }}"
     state: 'directory'
     recurse: yes
-  with_dict: '{{ app_configuration_files }}'
+  with_dict: '{{ app_configuration_files | combine(app_configuration_templates) }}'
 
-- name: 'Configuration: Render config files'
+- name: 'Configuration: Copy static config files'
   copy:
     src: "{{ app_files_local_folder }}/{{ item.key }}"
     dest: '{{ app_settings_path }}/{{ item.value }}'
   with_dict: '{{ app_configuration_files }}'
-  register: app_configs_status
+  register: app_config_files_status
+
+- name: 'Configuration: Render config templates'
+  template:
+    src: "{{ app_files_local_folder }}/{{ item.key }}"
+    dest: '{{ app_settings_path }}/{{ item.value }}'
+  with_dict: '{{ app_configuration_templates }}'
+  register: app_config_templates_status
 
 - name: 'Configuration: Prepare empty volumes list'
   set_fact:
@@ -26,5 +33,5 @@
 - name: 'Configuration: Prepare volumes list'
   set_fact:
     app_container_volumes: "{{ app_container_volumes|default([]) + [ app_settings_path + '/' + item.value + ':' + item.value + ':ro' ] }}"
-  with_dict: '{{ app_configuration_files }}'
-  changed_when: app_configs_status.changed
+  with_dict: '{{ app_configuration_files | combine(app_configuration_templates) }}'
+  changed_when: app_config_files_status.changed or app_config_templates_status.changed

--- a/tasks/_2_prepare_configs.yml
+++ b/tasks/_2_prepare_configs.yml
@@ -20,7 +20,7 @@
 
 - name: 'Configuration: Render config templates'
   template:
-    src: "{{ app_files_local_folder }}/{{ item.key }}"
+    src: "{{ app_templates_local_folder }}/{{ item.key }}"
     dest: '{{ app_settings_path }}/{{ item.value }}'
   with_dict: '{{ app_configuration_templates }}'
   register: app_config_templates_status

--- a/tasks/_4_run_app.yml
+++ b/tasks/_4_run_app.yml
@@ -7,7 +7,7 @@
     state: started
     restart: '{{ app_docker_image_status.changed }}'
     restart_policy: '{{ app_container_restart_policy }}'
-    recreate: '{{ app_configs_status.changed }}'
+    recreate: '{{ app_config_files_status.changed or app_config_templates_status.changed }}'
     command: '{{ app_command }}'
     ports: '{{ app_ports_mapping }}'
     env: '{{ app_container_environment }}'


### PR DESCRIPTION
The role supports only file copying to a container, but it might be useful to render a template instead. 

As a use case, it's might be useful to render ansible variables inside of `settings.local.yml` config.

It doesn't break backward compatibility, but adds a new functionality